### PR TITLE
Add Haskell CLAIR parser with validation and DAG detection

### DIFF
--- a/parser-hs/README.md
+++ b/parser-hs/README.md
@@ -1,0 +1,68 @@
+# CLAIR Parser (Haskell)
+
+A Haskell parser for CLAIR trace files with validation, DAG detection, and JSON export.
+
+## CLAIR Format
+
+```
+b1 1.0 L0 @user "User asks about Python"
+b2 0.95 L0 @self <b1 "Python is a programming language"
+b3 0.90 L1 @self <b2 "It supports multiple paradigms"
+```
+
+Each line: `id confidence level source [justifications] "content"`
+
+## Build
+
+```bash
+stack build
+```
+
+## Run
+
+```bash
+# Parse and validate
+stack exec clair-parser -- -i input.clair
+
+# Pretty print JSON
+stack exec clair-parser -- -i input.clair -o output.json -p
+
+# Validate only
+stack exec clair-parser -- -i input.clair --validate
+```
+
+## Test
+
+```bash
+stack test
+```
+
+## Modules
+
+- **Clair.Types** - Core data types (Belief, Confidence, Level, Source)
+- **Clair.Parser** - Attoparsec-based parser
+- **Clair.Validation** - DAG validation, cycle detection
+- **Clair.JSON** - JSON export/import
+
+## Features
+
+- ✅ Parse CLAIR trace format
+- ✅ Confidence bounds checking [0,1]
+- ✅ Level validation (non-negative)
+- ✅ DAG cycle detection
+- ✅ Duplicate ID detection
+- ✅ JSON export
+- ✅ CLI interface
+
+## Example
+
+```haskell
+import Clair.Parser
+import Clair.Validation
+
+main = do
+  let input = "b1 1.0 L0 @user \"Hello\""
+  case parseBelief input of
+    Right b  -> print $ validateBelief b
+    Left err -> putStrLn err
+```

--- a/parser-hs/app/Main.hs
+++ b/parser-hs/app/Main.hs
@@ -1,0 +1,108 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import qualified Data.ByteString.Lazy     as BL
+import           Data.Maybe               (fromMaybe)
+import qualified Data.Text                as T
+import qualified Data.Text.IO             as TIO
+import           Options.Applicative
+import           System.Exit              (exitFailure, exitSuccess)
+import           System.IO                (hPutStrLn, stderr)
+
+import           Clair.JSON
+import           Clair.Parser
+import           Clair.Types
+import           Clair.Validation
+
+-- | CLI options
+data Options = Options
+  { optInput    :: Maybe FilePath
+  , optOutput   :: Maybe FilePath
+  , optValidate :: Bool
+  , optPretty   :: Bool
+  }
+
+-- | Command line parser
+optionsParser :: Parser Options
+optionsParser = Options
+  <$> optional (strOption
+      $ long "input"
+     <> short 'i'
+     <> metavar "FILE"
+     <> help "Input CLAIR trace file (default: stdin)")
+  <*> optional (strOption
+      $ long "output"
+     <> short 'o'
+     <> metavar "FILE"
+     <> help "Output file (default: stdout)")
+  <*> switch
+      ( long "validate"
+     <> short 'v'
+     <> help "Validate only, no output")
+  <*> switch
+      ( long "pretty"
+     <> short 'p'
+     <> help "Pretty print JSON output")
+
+-- | Main entry point
+main :: IO ()
+main = do
+  opts <- execParser $ info (optionsParser <**> helper)
+    ( fullDesc
+   <> progDesc "Parse and validate CLAIR trace files"
+   <> header "clair-parser - A CLAIR trace file parser" )
+  runOptions opts
+
+runOptions :: Options -> IO ()
+runOptions opts = do
+  -- Read input
+  input <- case optInput opts of
+    Nothing    -> TIO.getContents
+    Just path  -> TIO.readFile path
+  
+  -- Parse
+  let (beliefs, parseErrors) = parseBeliefs input
+  
+  -- Report parse errors
+  case parseErrors of
+    [] -> return ()
+    es -> do
+      hPutStrLn stderr "Parse errors:"
+      mapM_ (\(n, e) -> hPutStrLn stderr $ "  Line " ++ show n ++ ": " ++ e) es
+  
+  -- Validate
+  case validateBeliefs beliefs of
+    Invalid errs -> do
+      hPutStrLn stderr "Validation errors:"
+      mapM_ (hPutStrLn stderr . ("  " ++) . showError) errs
+      exitFailure
+    Valid -> do
+      if optValidate opts
+        then putStrLn "Valid CLAIR file."
+        else outputResult opts beliefs
+
+outputResult :: Options -> [Belief] -> IO ()
+outputResult opts beliefs = do
+  let output = if optPretty opts 
+               then exportBeliefsToJSON beliefs
+               else beliefsToJSON beliefs
+  
+  case optOutput opts of
+    Nothing   -> BL.putStr output
+    Just path -> BL.writeFile path output
+
+-- | Format error messages
+showError :: ValidationError -> String
+showError (DuplicateId bid) = 
+  "Duplicate belief ID: " ++ T.unpack (unBeliefId bid)
+showError (InvalidConfidence c) = 
+  "Invalid confidence value: " ++ show c ++ " (must be in [0, 1])"
+showError (InvalidLevel n) = 
+  "Invalid level: " ++ show n ++ " (must be >= 0)"
+showError (MissingReference bid ref) = 
+  "Belief " ++ T.unpack (unBeliefId bid) ++ " references unknown belief: " ++ T.unpack (unBeliefId ref)
+showError (CycleDetected cycle) = 
+  "Cycle detected: " ++ unwords (map (T.unpack . unBeliefId) cycle)
+showError (InvalidSource src) = 
+  "Invalid source: " ++ T.unpack src

--- a/parser-hs/package.yaml
+++ b/parser-hs/package.yaml
@@ -1,0 +1,75 @@
+name:                clair-parser
+version:             0.1.0.0
+github:              "githubuser/clair-parser"
+license:             BSD-3-Clause
+author:              "Author name here"
+maintainer:          "example@example.com"
+copyright:           "2024 Author name here"
+
+extra-source-files:
+- README.md
+- CHANGELOG.md
+
+# Metadata used when publishing your package
+# synopsis:            Short description of your package
+# category:            Web
+
+# To avoid duplicated efforts in documentation and dealing with the
+# complications of embedding Haddock markup inside cabal files, it is
+# common to point people to the README.md file.
+description:         Please see the README on GitHub at <https://github.com/githubuser/clair-parser#readme>
+
+dependencies:
+- base >= 4.7 && < 5
+- text
+- attoparsec
+- aeson
+- scientific
+- containers
+- vector
+- bytestring
+- unordered-containers
+
+ghc-options:
+- -Wall
+- -Wcompat
+- -Widentities
+- -Wincomplete-record-updates
+- -Wincomplete-uni-patterns
+- -Wmissing-export-lists
+- -Wmissing-home-modules
+- -Wpartial-fields
+- -Wredundant-constraints
+
+library:
+  source-dirs: src
+  exposed-modules:
+  - Clair.Types
+  - Clair.Parser
+  - Clair.Validation
+  - Clair.JSON
+
+executables:
+  clair-parser:
+    main:                Main.hs
+    source-dirs:         app
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - clair-parser
+    - optparse-applicative
+
+tests:
+  clair-parser-test:
+    main:                Spec.hs
+    source-dirs:         test
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - clair-parser
+    - hspec
+    - QuickCheck

--- a/parser-hs/src/Clair/JSON.hs
+++ b/parser-hs/src/Clair/JSON.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Clair.JSON
+  ( beliefsToJSON
+  , beliefToJSON
+  , beliefStoreToJSON
+  , exportBeliefsToJSON
+  , exportBeliefsToJSONFile
+  , importBeliefsFromJSON
+  , importBeliefsFromJSONFile
+  ) where
+
+import           Data.Aeson                 (encode)
+import           Data.Aeson.Encode.Pretty   (Config(..), defConfig, 
+                                              encodePretty', keyOrder)
+import           Data.ByteString.Lazy       (ByteString)
+import qualified Data.ByteString.Lazy       as BL
+import qualified Data.ByteString.Lazy.Char8 as BLC8
+
+import           Clair.Types
+
+-- | Export a list of beliefs to JSON ByteString
+beliefsToJSON :: [Belief] -> ByteString
+beliefsToJSON = encode
+
+-- | Export a single belief to JSON ByteString
+beliefToJSON :: Belief -> ByteString
+beliefToJSON = encode
+
+-- | Export a belief store to JSON ByteString
+beliefStoreToJSON :: BeliefStore -> ByteString
+beliefStoreToJSON = encode . getAllBeliefs
+
+-- | Export beliefs to pretty-printed JSON ByteString
+exportBeliefsToJSON :: [Belief] -> ByteString
+exportBeliefsToJSON = encodePretty' prettyConfig
+  where
+    prettyConfig = defConfig
+      { confCompare = keyOrder ["id", "confidence", "level", "source", 
+                                "justifications", "content", "type", "references"]
+      , confIndent = Spaces 2
+      }
+
+-- | Export beliefs to a JSON file
+exportBeliefsToJSONFile :: FilePath -> [Belief] -> IO ()
+exportBeliefsToJSONFile path beliefs = BL.writeFile path (exportBeliefsToJSON beliefs)
+
+-- | Import beliefs from JSON ByteString
+importBeliefsFromJSON :: ByteString -> Either String [Belief]
+importBeliefsFromJSON = eitherDecode
+
+-- | Import beliefs from a JSON file
+importBeliefsFromJSONFile :: FilePath -> IO (Either String [Belief])
+importBeliefsFromJSONFile path = importBeliefsFromJSON <$> BL.readFile path

--- a/parser-hs/src/Clair/Parser.hs
+++ b/parser-hs/src/Clair/Parser.hs
@@ -1,0 +1,214 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Clair.Parser
+  ( -- * Parsers
+    parseBelief
+  , parseBeliefLine
+  , parseBeliefs
+  , parseBeliefsFromText
+  , parseBeliefsFromFile
+    -- * Individual component parsers
+  , beliefIdParser
+  , confidenceParser
+  , levelParser
+  , sourceParser
+  , justificationParser
+  , contentParser
+  , parsedContentParser
+  ) where
+
+import           Control.Applicative (optional, (<|>))
+import           Data.Attoparsec.Text
+import           Data.Char           (isAlphaNum, isDigit)
+import           Data.Scientific     (Scientific)
+import           Data.Text           (Text)
+import qualified Data.Text           as T
+import qualified Data.Text.IO        as TIO
+
+import           Clair.Types
+
+-- | Parse a belief ID (e.g., "b1", "b2", "belief_123")
+-- Format: letter followed by alphanumeric characters
+beliefIdParser :: Parser BeliefId
+beliefIdParser = do
+  first <- satisfy (\c -> (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z'))
+  rest <- takeWhile (\c -> isAlphaNum c || c == '_' || c == '-')
+  skipSpace
+  return $ BeliefId $ T.cons first rest
+
+-- | Parse a confidence value (scientific notation or decimal)
+-- Must be in range [0, 1]
+confidenceParser :: Parser Confidence
+confidenceParser = do
+  num <- scientific
+  skipSpace
+  case mkConfidence num of
+    Just c  -> return c
+    Nothing -> fail $ "Confidence must be in [0, 1], got: " ++ show num
+
+-- | Parse a level (L0, L1, L2, ...)
+levelParser :: Parser Level
+levelParser = do
+  _ <- char 'L' <|> char 'l'
+  n <- decimal
+  skipSpace
+  return $ Level (fromIntegral n)
+
+-- | Parse a source (@user, @self, @file:path, @model:name)
+sourceParser :: Parser Source
+sourceParser = do
+  _ <- char '@'
+  src <- takeWhile1 (\c -> isAlphaNum c || c == '_' || c == '-')
+  case src of
+    "user" -> skipSpace >> return SourceUser
+    "self" -> skipSpace >> return SourceSelf
+    _      -> do
+      -- Check for file: or model: prefix
+      case T.breakOn ":" src of
+        ("file", rest) | not (T.null rest) -> do
+          let path = T.tail rest
+          skipSpace
+          return $ SourceFile (T.unpack path)
+        ("model", rest) | not (T.null rest) -> do
+          let name = T.tail rest
+          skipSpace
+          return $ SourceModel name
+        _ -> fail $ "Unknown source: @" ++ T.unpack src
+
+-- | Parse a single justification reference (<id)
+justificationParser :: Parser Justification
+justificationParser = do
+  _ <- char '<'
+  bid <- beliefIdParser
+  return $ Justification bid
+
+-- | Parse a quoted string content
+-- Supports escaped quotes: \"
+quotedStringParser :: Parser Text
+quotedStringParser = do
+  _ <- char '"'
+  content <- T.concat <$> many' (escapedQuote <|> plainChar)
+  _ <- char '"'
+  return content
+  where
+    escapedQuote = T.singleton <$> (char '\\' *> char '"')
+    plainChar = takeWhile1 (/= '"') <|> (char '\\' >> return "\\")
+
+-- | Parse plain content (just a quoted string)
+plainContentParser :: Parser ParsedContent
+plainContentParser = PlainContent <$> quotedStringParser
+
+-- | Parse derived content with justifications (<id1 <id2 "content")
+derivedContentParser :: Parser ParsedContent
+derivedContentParser = do
+  refs <- many1' justificationParser
+  skipSpace
+  content <- quotedStringParser
+  return $ DerivedContent refs content
+
+-- | Parse either plain or derived content
+parsedContentParser :: Parser ParsedContent
+parsedContentParser = 
+  (do lookAhead (char '<'); derivedContentParser) <|> plainContentParser
+
+-- | Parse optional justifications appearing after source and before content
+optionalJustifications :: Parser [Justification]
+optionalJustifications = many' $ do
+  skipSpace
+  ref <- justificationParser
+  skipSpace
+  return ref
+
+-- | Parse a complete belief line
+beliefParser :: Parser Belief
+beliefParser = do
+  -- Parse ID
+  bid <- beliefIdParser
+  
+  -- Parse confidence
+  conf <- confidenceParser
+  
+  -- Parse level
+  lvl <- levelParser
+  
+  -- Parse source
+  src <- sourceParser
+  
+  -- Parse optional justifications
+  justs <- optionalJustifications
+  
+  -- Parse content
+  content <- parsedContentParser
+  
+  -- Handle end of line
+  skipSpace
+  optional endOfLine
+  
+  return $ Belief
+    { beliefId = bid
+    , beliefConfidence = conf
+    , beliefLevel = lvl
+    , beliefSource = src
+    , beliefJustifications = justs
+    , beliefContent = content
+    }
+
+-- | Parse a single belief from Text (allows leading/trailing whitespace)
+parseBelief :: Text -> Either String Belief
+parseBelief = parseOnly (skipSpace *> beliefParser <* skipSpace <* endOfInput)
+
+-- | Parse a single belief line (doesn't require consuming all input)
+parseBeliefLine :: Text -> Either String Belief
+parseBeliefLine = parseOnly (skipSpace *> beliefParser)
+
+-- | Parse multiple beliefs from text (one per line)
+-- Empty lines and comment lines (starting with #) are ignored
+beliefsParser :: Parser [Belief]
+beliefsParser = do
+  skipSpace
+  many' $ do
+    -- Skip empty lines and comments
+    skipMany $ do
+      skipSpace
+      optional (char '#' *> takeTill isEndOfLine *> endOfLine)
+      skipSpace
+      endOfLine
+    
+    -- Try to parse a belief
+    mb <- optional beliefParser
+    case mb of
+      Just b  -> return b
+      Nothing -> do
+        -- If we can't parse a belief, check if we're at end
+        atEnd <- atEnd
+        if atEnd
+          then fail "No more beliefs"
+          else do
+            -- Skip this line and try next
+            takeTill isEndOfLine
+            optional endOfLine
+            skipSpace
+            return undefined  -- Will be filtered out
+  >>= \bs -> return $ filter (/= undefined) bs
+
+-- | Parse multiple beliefs from Text
+parseBeliefsFromText :: Text -> Either String [Belief]
+parseBeliefsFromText = parseOnly (beliefsParser <* skipSpace <* endOfInput)
+
+-- | Parse beliefs from a file
+parseBeliefsFromFile :: FilePath -> IO (Either String [Belief])
+parseBeliefsFromFile path = parseBeliefsFromText <$> TIO.readFile path
+
+-- | Parse beliefs with error handling for individual lines
+parseBeliefs :: Text -> ([Belief], [(Int, String)])
+parseBeliefs text = 
+  let lines' = zip [1..] (T.lines text)
+      results = map parseLine lines'
+      beliefs = [b | (_, Right b) <- results]
+      errors  = [(n, e) | (n, Left e) <- results]
+  in (beliefs, errors)
+  where
+    parseLine (n, line) 
+      | T.null (T.strip line) = (n, Left "Empty line")
+      | "#" `T.isPrefixOf` T.strip line = (n, Left "Comment")
+      | otherwise = (n, parseBeliefLine line)

--- a/parser-hs/src/Clair/Types.hs
+++ b/parser-hs/src/Clair/Types.hs
@@ -1,0 +1,269 @@
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Clair.Types
+  ( -- * Core Types
+    BeliefId(..)
+  , Confidence(..)
+  , Level(..)
+  , Source(..)
+  , Justification(..)
+  , Belief(..)
+  , BeliefStore(..)
+  , ValidationError(..)
+  , ValidationResult(..)
+  , ParsedContent(..)
+    -- * Constructors
+  , mkConfidence
+  , mkConfidenceUnsafe
+  , mkLevel
+  , mkBeliefId
+  , emptyBeliefStore
+  , addBelief
+  , lookupBelief
+  , getAllBeliefs
+    -- * Predicates
+  , isValidConfidence
+  , isUserSource
+  , isSelfSource
+  , isFileSource
+  , isModelSource
+  ) where
+
+import           Data.Aeson      (FromJSON, ToJSON, object, pairs, parseJSON,
+                                  toEncoding, toJSON, withObject, withText,
+                                  (.:), (.=))
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import           Data.Scientific (Scientific, toRealFloat)
+import           Data.Text       (Text)
+import qualified Data.Text       as T
+import           GHC.Generics    (Generic)
+
+-- | Unique identifier for a belief (e.g., "b1", "b2")
+newtype BeliefId = BeliefId { unBeliefId :: Text }
+  deriving (Eq, Ord, Generic, Show)
+
+instance ToJSON BeliefId where
+  toJSON = toJSON . unBeliefId
+  toEncoding = toEncoding . unBeliefId
+
+instance FromJSON BeliefId where
+  parseJSON = withText "BeliefId" (pure . BeliefId)
+
+-- | Create a BeliefId from Text
+mkBeliefId :: Text -> BeliefId
+mkBeliefId = BeliefId
+
+-- | Confidence value in [0, 1]
+newtype Confidence = Confidence { unConfidence :: Scientific }
+  deriving (Eq, Ord, Generic, Show)
+
+instance ToJSON Confidence where
+  toJSON = toJSON . unConfidence
+  toEncoding = toEncoding . unConfidence
+
+instance FromJSON Confidence where
+  parseJSON v = do
+    sci <- parseJSON v
+    if isValidConfidence sci
+      then pure $ Confidence sci
+      else fail $ "Confidence must be in [0, 1], got: " ++ show sci
+
+-- | Check if a scientific number is a valid confidence value
+isValidConfidence :: Scientific -> Bool
+isValidConfidence s = s >= 0 && s <= 1
+
+-- | Smart constructor for confidence (returns Nothing if out of bounds)
+mkConfidence :: Scientific -> Maybe Confidence
+mkConfidence s
+  | isValidConfidence s = Just $ Confidence s
+  | otherwise           = Nothing
+
+-- | Unsafe constructor for confidence (use with caution)
+mkConfidenceUnsafe :: Scientific -> Confidence
+mkConfidenceUnsafe = Confidence
+
+-- | Level of belief (L0, L1, L2, ...)
+newtype Level = Level { unLevel :: Int }
+  deriving (Eq, Ord, Generic, Show)
+
+instance ToJSON Level where
+  toJSON = toJSON . unLevel
+  toEncoding = toEncoding . unLevel
+
+instance FromJSON Level where
+  parseJSON v = Level <$> parseJSON v
+
+-- | Create a level from an integer
+mkLevel :: Int -> Level
+mkLevel = Level
+
+-- | Source of a belief
+data Source
+  = SourceUser              -- ^ @user
+  | SourceSelf              -- ^ @self
+  | SourceFile FilePath     -- ^ @file:path
+  | SourceModel Text        -- ^ @model:name
+  deriving (Eq, Generic, Show)
+
+instance ToJSON Source where
+  toJSON SourceUser     = "user"
+  toJSON SourceSelf     = "self"
+  toJSON (SourceFile p) = object ["type" .= ("file" :: Text), "path" .= p]
+  toJSON (SourceModel n) = object ["type" .= ("model" :: Text), "name" .= n]
+  
+  toEncoding SourceUser     = toEncoding ("user" :: Text)
+  toEncoding SourceSelf     = toEncoding ("self" :: Text)
+  toEncoding (SourceFile p) = pairs $ "type" .= ("file" :: Text) <> "path" .= p
+  toEncoding (SourceModel n) = pairs $ "type" .= ("model" :: Text) <> "name" .= n
+
+instance FromJSON Source where
+  parseJSON = withText "Source" $ \t ->
+    case t of
+      "user" -> pure SourceUser
+      "self" -> pure SourceSelf
+      _      -> fail $ "Unknown source: " ++ T.unpack t
+
+-- | Source predicates
+isUserSource :: Source -> Bool
+isUserSource SourceUser = True
+isUserSource _          = False
+
+isSelfSource :: Source -> Bool
+isSelfSource SourceSelf = True
+isSelfSource _          = False
+
+isFileSource :: Source -> Bool
+isFileSource (SourceFile _) = True
+isFileSource _              = False
+
+isModelSource :: Source -> Bool
+isModelSource (SourceModel _) = True
+isModelSource _               = False
+
+-- | Justification reference to another belief
+newtype Justification = Justification { unJustification :: BeliefId }
+  deriving (Eq, Ord, Generic, Show)
+
+instance ToJSON Justification where
+  toJSON = toJSON . unJustification
+  toEncoding = toEncoding . unJustification
+
+instance FromJSON Justification where
+  parseJSON v = Justification <$> parseJSON v
+
+-- | The content of a belief (can be plain text or derived)
+data ParsedContent
+  = PlainContent Text                    -- ^ "content here"
+  | DerivedContent [Justification] Text  -- ^ <b1 "derived content"
+  deriving (Eq, Generic, Show)
+
+instance ToJSON ParsedContent where
+  toJSON (PlainContent t) = object
+    [ "type"    .= ("plain" :: Text)
+    , "content" .= t
+    ]
+  toJSON (DerivedContent refs t) = object
+    [ "type"    .= ("derived" :: Text)
+    , "references" .= refs
+    , "content" .= t
+    ]
+  
+  toEncoding (PlainContent t) = pairs $
+    "type"    .= ("plain" :: Text) <>
+    "content" .= t
+  toEncoding (DerivedContent refs t) = pairs $
+    "type"       .= ("derived" :: Text) <>
+    "references" .= refs <>
+    "content"    .= t
+
+instance FromJSON ParsedContent where
+  parseJSON = withObject "ParsedContent" $ \o -> do
+    ty <- o .: "type"
+    case (ty :: Text) of
+      "plain"   -> PlainContent <$> o .: "content"
+      "derived" -> DerivedContent <$> o .: "references" <*> o .: "content"
+      _         -> fail $ "Unknown content type: " ++ T.unpack ty
+
+-- | A belief with all its attributes
+data Belief = Belief
+  { beliefId       :: !BeliefId
+  , beliefConfidence :: !Confidence
+  , beliefLevel    :: !Level
+  , beliefSource   :: !Source
+  , beliefJustifications :: ![Justification]
+  , beliefContent  :: !ParsedContent
+  } deriving (Eq, Generic, Show)
+
+instance ToJSON Belief where
+  toJSON b = object
+    [ "id"            .= beliefId b
+    , "confidence"    .= beliefConfidence b
+    , "level"         .= beliefLevel b
+    , "source"        .= beliefSource b
+    , "justifications".= beliefJustifications b
+    , "content"       .= beliefContent b
+    ]
+  
+  toEncoding b = pairs $
+    "id"             .= beliefId b <>
+    "confidence"     .= beliefConfidence b <>
+    "level"          .= beliefLevel b <>
+    "source"         .= beliefSource b <>
+    "justifications" .= beliefJustifications b <>
+    "content"        .= beliefContent b
+
+instance FromJSON Belief where
+  parseJSON = withObject "Belief" $ \o -> Belief
+    <$> o .: "id"
+    <*> o .: "confidence"
+    <*> o .: "level"
+    <*> o .: "source"
+    <*> o .: "justifications"
+    <*> o .: "content"
+
+-- | Store for managing beliefs
+newtype BeliefStore = BeliefStore
+  { unBeliefStore :: Map BeliefId Belief
+  } deriving (Eq, Show)
+
+-- | Create an empty belief store
+emptyBeliefStore :: BeliefStore
+emptyBeliefStore = BeliefStore M.empty
+
+-- | Add a belief to the store
+addBelief :: Belief -> BeliefStore -> BeliefStore
+addBelief b (BeliefStore m) = BeliefStore $ M.insert (beliefId b) b m
+
+-- | Look up a belief by ID
+lookupBelief :: BeliefId -> BeliefStore -> Maybe Belief
+lookupBelief bid (BeliefStore m) = M.lookup bid m
+
+-- | Get all beliefs from the store
+getAllBeliefs :: BeliefStore -> [Belief]
+getAllBeliefs (BeliefStore m) = M.elems m
+
+-- | Validation errors
+data ValidationError
+  = DuplicateId BeliefId
+  | InvalidConfidence Scientific
+  | InvalidLevel Int
+  | MissingReference BeliefId BeliefId  -- ^ belief id, missing reference id
+  | CycleDetected [BeliefId]
+  | InvalidSource Text
+  deriving (Eq, Show)
+
+-- | Result of validation
+data ValidationResult
+  = Valid
+  | Invalid [ValidationError]
+  deriving (Eq, Show)
+
+instance Semigroup ValidationResult where
+  Valid <> x = x
+  x <> Valid = x
+  (Invalid es1) <> (Invalid es2) = Invalid (es1 ++ es2)
+
+instance Monoid ValidationResult where
+  mempty = Valid

--- a/parser-hs/src/Clair/Validation.hs
+++ b/parser-hs/src/Clair/Validation.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Clair.Validation
+  ( validateBelief
+  , validateBeliefs
+  , validateDAG
+  , checkReferencesExist
+  , buildBeliefStore
+  ) where
+
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import           Data.Set        (Set)
+import qualified Data.Set        as S
+import           Data.Text       (Text)
+
+import           Clair.Types
+
+-- | Validate a single belief
+validateBelief :: Belief -> ValidationResult
+validateBelief b = 
+  checkConfidenceBounds (beliefConfidence b) <>
+  checkLevelBounds (beliefLevel b)
+
+-- | Check confidence is in valid bounds [0, 1]
+checkConfidenceBounds :: Confidence -> ValidationResult
+checkConfidenceBounds (Confidence c)
+  | c >= 0 && c <= 1 = Valid
+  | otherwise        = Invalid [InvalidConfidence c]
+
+-- | Check level is non-negative
+checkLevelBounds :: Level -> ValidationResult
+checkLevelBounds (Level n)
+  | n >= 0    = Valid
+  | otherwise = Invalid [InvalidLevel n]
+
+-- | Build dependency graph from beliefs
+buildDependencyGraph :: [Belief] -> Map BeliefId (Set BeliefId)
+buildDependencyGraph beliefs =
+  M.fromList $ map (\b -> (beliefId b, getDependencies b)) beliefs
+  where
+    getDependencies b = S.fromList $ map unJustification $ beliefJustifications b
+
+-- | Detect cycles using DFS
+detectCycles :: Map BeliefId (Set BeliefId) -> Maybe [BeliefId]
+detectCycles graph = go [] S.empty (M.keysSet graph)
+  where
+    go path visited remaining
+      | S.null remaining = Nothing
+      | otherwise =
+          let current = S.findMin remaining
+          in dfs current path visited (S.delete current remaining)
+    
+    dfs node path visited remaining
+      | node `elem` path = Just $ dropWhile (/= node) (path ++ [node])
+      | node `S.member` visited = go path (S.insert node visited) remaining
+      | otherwise =
+          case M.lookup node graph of
+            Nothing -> go (path ++ [node]) (S.insert node visited) remaining
+            Just deps ->
+              let depsList = S.toList deps
+              in checkDeps depsList (node:path) (S.insert node visited) remaining
+    
+    checkDeps [] path' visited' remaining' = go path' visited' remaining'
+    checkDeps (d:ds) path' visited' remaining' =
+      case dfs d path' visited' remaining' of
+        Just cycle -> Just cycle
+        Nothing    -> checkDeps ds path' visited' remaining'
+
+-- | Validate that beliefs form a DAG (no cycles)
+validateDAG :: [Belief] -> ValidationResult
+validateDAG beliefs =
+  let graph = buildDependencyGraph beliefs
+  in case detectCycles graph of
+       Nothing -> Valid
+       Just cycle -> Invalid [CycleDetected cycle]
+
+-- | Check for duplicate IDs
+checkDuplicateIds :: [Belief] -> ValidationResult
+checkDuplicateIds beliefs =
+  let ids = map beliefId beliefs
+      grouped = foldr (\bid m -> M.insertWith (++) bid [bid] m) M.empty ids
+      dups = M.filter (\v -> length v > 1) grouped
+  in if M.null dups
+     then Valid
+     else Invalid $ map DuplicateId (M.keys dups)
+
+-- | Check that all justifications reference existing beliefs
+checkReferencesExist :: Belief -> BeliefStore -> ValidationResult
+checkReferencesExist belief store =
+  let refs = map unJustification $ beliefJustifications belief
+      missing = filter (\r -> lookupBelief r store == Nothing) refs
+  in if null missing
+     then Valid
+     else Invalid $ map (MissingReference (beliefId belief)) missing
+
+-- | Validate a list of beliefs
+validateBeliefs :: [Belief] -> ValidationResult
+validateBeliefs beliefs = 
+  let individual = mconcat $ map validateBelief beliefs
+      dagCheck = validateDAG beliefs
+      duplicateCheck = checkDuplicateIds beliefs
+  in individual <> dagCheck <> duplicateCheck
+
+-- | Build a belief store with validation
+buildBeliefStore :: [Belief] -> Either [ValidationError] BeliefStore
+buildBeliefStore beliefs =
+  case validateBeliefs beliefs of
+    Valid      -> Right $ foldr addBelief emptyBeliefStore beliefs
+    Invalid es -> Left es

--- a/parser-hs/stack.yaml
+++ b/parser-hs/stack.yaml
@@ -1,0 +1,6 @@
+resolver: lts-22.28
+
+packages:
+- .
+
+extra-deps: []

--- a/parser-hs/test/Spec.hs
+++ b/parser-hs/test/Spec.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import           Test.Hspec
+import           Test.QuickCheck
+
+import           Clair.Types
+import           Clair.Parser
+import           Clair.Validation
+
+main :: IO ()
+main = hspec $ do
+  describe "Clair.Types" $ do
+    it "creates valid confidence values" $ do
+      mkConfidence 0.5 `shouldBe` Just (Confidence 0.5)
+      mkConfidence 1.0 `shouldBe` Just (Confidence 1.0)
+      mkConfidence 0.0 `shouldBe` Just (Confidence 0.0)
+    
+    it "rejects invalid confidence values" $ do
+      mkConfidence 1.5 `shouldBe` Nothing
+      mkConfidence (-0.1) `shouldBe` Nothing
+  
+  describe "Clair.Parser" $ do
+    it "parses a simple belief" $ do
+      let input = "b1 1.0 L0 @user \"test content\""
+          result = parseBelief input
+      case result of
+        Right b -> do
+          beliefId b `shouldBe` BeliefId "b1"
+          beliefLevel b `shouldBe` Level 0
+          beliefSource b `shouldBe` SourceUser
+        Left e -> expectationFailure $ "Parse failed: " ++ e
+    
+    it "parses confidence with shorthand notation" $ do
+      let input = "b1 .95 L0 @user \"content\""
+          result = parseBelief input
+      case result of
+        Right b -> unConfidence (beliefConfidence b) `shouldBe` 0.95
+        Left e -> expectationFailure $ "Parse failed: " ++ e
+    
+    it "parses derived content with justifications" $ do
+      let input = "b2 .9 L1 @self <b1 \"derived\""
+          result = parseBelief input
+      case result of
+        Right b -> do
+          beliefSource b `shouldBe` SourceSelf
+          length (beliefJustifications b) `shouldBe` 1
+        Left e -> expectationFailure $ "Parse failed: " ++ e
+    
+    it "parses multiple beliefs" $ do
+      let input = "b1 1.0 L0 @user \"first\"\nb2 .9 L1 @self \"second\""
+          (beliefs, errors) = parseBeliefs input
+      length beliefs `shouldBe` 2
+      length errors `shouldBe` 0
+    
+    it "handles empty lines and comments" $ do
+      let input = "# comment\nb1 1.0 L0 @user \"test\"\n\nb2 .9 L0 @self \"test2\""
+          (beliefs, _) = parseBeliefs input
+      length beliefs `shouldBe` 2
+  
+  describe "Clair.Validation" $ do
+    it "validates confidence bounds" $ do
+      let b = Belief (BeliefId "b1") (mkConfidenceUnsafe 0.5) (Level 0) 
+                   SourceUser [] (PlainContent "test")
+      validateBelief b `shouldBe` Valid
+    
+    it "detects duplicate IDs" $ do
+      let b1 = Belief (BeliefId "b1") (mkConfidenceUnsafe 1.0) (Level 0) 
+                    SourceUser [] (PlainContent "test1")
+          b2 = Belief (BeliefId "b1") (mkConfidenceUnsafe 0.9) (Level 0) 
+                    SourceUser [] (PlainContent "test2")
+      case validateBeliefs [b1, b2] of
+        Invalid errs -> any isDuplicateError errs `shouldBe` True
+        Valid -> expectationFailure "Expected duplicate ID error"
+    
+    it "detects cycles" $ do
+      let b1 = Belief (BeliefId "b1") (mkConfidenceUnsafe 1.0) (Level 0) 
+                    SourceUser [Justification (BeliefId "b2")] (PlainContent "test1")
+          b2 = Belief (BeliefId "b2") (mkConfidenceUnsafe 0.9) (Level 0) 
+                    SourceUser [Justification (BeliefId "b1")] (PlainContent "test2")
+      case validateDAG [b1, b2] of
+        Invalid errs -> any isCycleError errs `shouldBe` True
+        Valid -> expectationFailure "Expected cycle detection"
+
+isDuplicateError :: ValidationError -> Bool
+isDuplicateError (DuplicateId _) = True
+isDuplicateError _ = False
+
+isCycleError :: ValidationError -> Bool
+isCycleError (CycleDetected _) = True
+isCycleError _ = False


### PR DESCRIPTION
This PR adds a complete Haskell implementation of a CLAIR trace parser.

## What's Included

A full Haskell Stack project in `parser-hs/`:

### Modules
- **Clair.Types** - Core data types (BeliefId, Confidence, Level, Source, Belief)
- **Clair.Parser** - Attoparsec-based parser for CLAIR format
- **Clair.Validation** - DAG validation with cycle detection (DFS)
- **Clair.JSON** - JSON export using Aeson

### CLI
- Executable with optparse-applicative
- Options: --input, --output, --validate, --pretty
- Reads stdin or file, outputs JSON

### Features
- ✅ Parse CLAIR trace format
- ✅ Confidence bounds checking [0,1]
- ✅ Level validation (non-negative)
- ✅ **DAG cycle detection** - prevents circular justifications
- ✅ Duplicate ID detection
- ✅ JSON export (pretty or compact)
- ✅ HSpec test suite

## Example Usage

```bash
cd parser-hs
stack build
stack exec clair-parser -- -i example.clair -o output.json -p
```

## Build & Test

```bash
stack build
stack test
```

---
*Contributed by Stone (@hmemcpy'\''s agent)*